### PR TITLE
broke some things, fixed some thingss

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,11 +28,11 @@
       </li>
     </script>
     <script id="template_project_menu_item" type="text/x-handlebars-template">
-      <li><a href="/projects/{{category}}/{{title}}">{{title}}</a></li>
+      <li><a href="/projects/{{category}}/{{despace title}}">{{title}}</a></li>
     </script>
 
     <script id="template_project" type="text/x-handlebars-template">
-      <article data-category="{{category}}" data-project="{{title}}" class="{{category}}" id="{{title}}">
+      <article data-category="{{category}}" data-project="{{title}}" class="{{category}}" id="{{despace title}}">
         <div class="card_contents">
           <div class="info_and_img">
             <ul class="content_list">
@@ -57,7 +57,7 @@
     <script id="template_github" type="text/x-handlebars-template">
       <ul>
         <li>{{name}}</li>
-        <li>{{prettifyDate updated_at}}</li>
+        <li>{{prettifyDate status}}</li>
         <li><a href="{{html_url}}">{{html_url}}</a></li>
         <li>{{deployments_url}}</li>
         <li>{{description}}</li>

--- a/scripts/index_view.js
+++ b/scripts/index_view.js
@@ -8,40 +8,43 @@
     $('article').each(function() {
       if (!$(this).hasClass('template')) {
         var val = $(this).attr('data-project');
-        var optionTag = '<option value="' + val + '">' + val + '</option>';
+        var optionTag = '<option value="' + val.replace(/\W+/g, '') + '">' + val + '</option>';
         $('#filter_project').append(optionTag);
 
         val = $(this).attr('data-category');
-        optionTag = '<option value="' + val + '">' + val + '</option>';
-        if ($('#filter_category option[value="' + val + '"]').length === 0) {
+        optionTag = '<option value="' + val.replace(/\W+/g, '') + '">' + val + '</option>';
+        if ($('#filter_category option[value="' + val.replace(/\W+/g, '') + '"]').length === 0) {
           $('#filter_category').append(optionTag);
         }
       }
     });
   };
 
+  // WORK IN PROGRESS:  FIX FILTERS IN MOBILE VIEW...  migrate to single handler?
+  // restructure the way things are populated.
+
+  // index_view.handleFilters = function() {
+  //   console.log('handling filters');
+  //   $('#filters').one('change', 'select', function() {
+  //     console.log('you got filtered son!');
+  //     var resource = this.id.replace('filter_', '');
+  //     page('/' + resource + '/' + $(this).val().replace(/\W+/g, '')); // Replace any/all whitespace with a +
+  //     console.log('filterstep3');
+  //   });
+  // };
+
   index_view.handleCategoryFilter = function() {
     $('#filter_category').on('change', function() {
-      if ($(this).val()) {
-        $('article').hide();
-        $('article[data-category="' + $(this).val() + '"]').fadeIn();
-      } else {
-        $('article').fadeIn();
-        $('article.template').hide();
-      }
+      $('article').hide();
+      $('.' + $(this).val().replace(/\W+/g, '')).fadeIn();
       $('#filter_project').val('');
     });
   };
 
   index_view.handleProjectFilter = function() {
     $('#filter_project').on('change', function() {
-      if ($(this).val()) {
-        $('article').hide();
-        $('article[data-project="' + $(this).val() + '"]').fadeIn();
-      } else {
-        $('article').fadeIn();
-        $('article.template').hide();
-      }
+      $('article').hide();
+      $('#' + $(this).val().replace(/\W+/g, '')).fadeIn();
       $('#filter_category').val('');
     });
   };
@@ -58,6 +61,7 @@
     });
 
     index_view.populateFilters();
+    // index_view.handleFilters();  // this filter method is broken... On the bright side we're temporarily saving users from pretending like mobile isn't an absolutely terrible way to view any website ever made in the history of man, because screen made for ants...,  so that's a bonus
     index_view.handleProjectFilter();
     index_view.handleCategoryFilter();
     $('.projects').hide();

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -24,8 +24,13 @@
   Project.prototype.toHtml = function(loc) {
     var template = Handlebars.compile($(loc).text());
 
-    Handlebars.registerHelper('prettifyDate', function(timestamp) {
-      return new Date(timestamp).toString('yyyy-mm-dd');
+    Handlebars.registerHelper('despace', function() {
+      return this.title.replace(/\W+/g, '');
+    });
+
+    Handlebars.registerHelper('prettifyDate', function() {
+      this.completed_days = parseInt((new Date() - new Date(this.completed))/60/60/24/1000);
+      return this.status = this.completed ? this.completed_days + ' days ago' : '(in progress)';
     });
 
     return template(this);
@@ -33,6 +38,11 @@
 
   Categories.prototype.toHtml = function() {
     var template = Handlebars.compile($('#template_project_menu').text());
+
+    Handlebars.registerHelper('despace', function() {
+      return this.title.replace(/\W+/g, '');
+    });
+
     return template(this);
   };
 
@@ -50,11 +60,9 @@
     data_projects.sort(function(a,b) {
       return (new Date(a.completed)) - (new Date(b.completed));
     });
-
     data_projects.forEach(function(ele) {
       Project.all.push(new Project(ele));
     });
-
     Project.allCategoriesFilter().forEach(function(ele) {
       Categories.all.push(new Categories(ele));
     });
@@ -69,7 +77,6 @@
           console.log(xhr);
           var eTag = xhr.getResponseHeader('eTag');
           if (!localStorage.eTag || eTag !== localStorage.eTag) {
-            // localStorage.clear();
             localStorage.eTag = eTag;
             Project.getData();
           } else {

--- a/scripts/project_controller.js
+++ b/scripts/project_controller.js
@@ -8,16 +8,19 @@
     $('.projects').show();
   };
 
-  controller_project.index_course = function(ctx) {
+  controller_project.index_course = function(ctx, next) {
     console.log(ctx.params.category);
     $('article').hide();
     $('.' + ctx.params.category).show();
+    next;
   };
 
-  controller_project.index_item = function(ctx) {
-    console.log(ctx.params.project);
+  controller_project.index_item = function(ctx, next) {
+    var project_despace = ctx.params.project.replace(/\W+/g, '');
+    console.log('project_despace: ' + project_despace);
     $('article').hide();
-    $('#' + ctx.params.project).show();
+    $('#' + project_despace).show();
+    next;
   };
 
   module.controller_project = controller_project;

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -2,9 +2,9 @@ page('/', controller_home.index);
 page('/projects', controller_project.index);
 page('/about', controller_about.index);
 page('/projects/:category', controller_project.index_course);
-page('/projects/:category/:project', controller_project.index_item);  // THIS IS NOT SORT OF CURRENTLY WORKING.  NEED TROUBLESHOOTING.
+page('/projects/:category/:project', controller_project.index_item);  // THIS IS SORT OF NOT CURRENTLY WORKING.  NEED TROUBLESHOOTING.
 // line 5 bugs:  any projects with spaces in the title will not be loaded.  link replaces space with %20 while id containes space... 2 ids...   :/
-// possible solution:  slice title along delimiter (space) and concat for href of a and for id.
+// possible solution:  use regex or slice title along delimiter (space) and concat for href of a and for id.
 // Name all projects with underscores and replace for actual title possibly?
 
 page();


### PR DESCRIPTION
added next callback in case of future use to several functions.
filters (mobile) / menu links (desktop) now work properly for selecting project by title \o/
added helper function to Handlebars template to allow titles to be selected from filter / link
refactored filter handler to streamline code.

TODO:  refactor handlers into single handler
TODO:  cause handlers to set new path (maybe... using show/hide to make page more fluid currently)
TODO:  change how data is stored in GitHub repos.  add keyword / value pairs to title and/or description that can be extracted with string matching.
TODO:  re-write entire back end code to be coherent and not bodged together over the course of 14+ different topics' material  pair this with previous TODO to retrieve data from local storage / GitHub, parse to JSON object (local storage?) (one item? many item?) only the first time each 'page' loads 
TODO:  change how pages load.  either pre-load contents or load contents only the first time a page is called and show/hide contents when navigating to / from page.  If too many projects are displayed, limit how many are called and/or switch to ajax calls to display 5-10 project per page
TODO:  add contact page
